### PR TITLE
Add flake.nix for easier installation on nix systems

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ __pycache__
 # Ruff
 
 .ruff_cache
+
+# Direnv
+.direnv

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__
 
 # Direnv
 .direnv
+.nix-venv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734747996,
+        "narHash": "sha256-0DUuObdcPITVOMMymq2y6YlM++QEWXZO3cTm6RGYgL8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f9086701f5f3d36b8e5f4a3b9c93579ebc2581e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,31 @@
         "type": "github"
       }
     },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734658408,
+        "narHash": "sha256-HdHkeJ506zKDOrCvsMoZllrOs1sol6bYbv1DifDtas0=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "139a84af40ed51c87f27708fcbe196bd6f189efd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "pyproject-nix": "pyproject-nix",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -34,31 +34,10 @@
         "type": "github"
       }
     },
-    "pyproject-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1734658408,
-        "narHash": "sha256-HdHkeJ506zKDOrCvsMoZllrOs1sol6bYbv1DifDtas0=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "139a84af40ed51c87f27708fcbe196bd6f189efd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "pyproject-nix": "pyproject-nix",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -17,9 +17,18 @@
       system: let
         overlays = [(import rust-overlay)];
         pkgs = import nixpkgs {inherit system overlays;};
+
+        rustPkg = pkgs.rust-bin.stable.latest.default;
+        pythonPkg = pkgs.python3;
       in {
         devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [alejandra python313 rust-bin.stable.latest.default];
+          buildInputs = with pkgs; [alejandra maturin pythonPkg rustPkg];
+
+          shellHook = ''
+            export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib.outPath}/lib:${pkgs.pythonManylinuxPackages.manylinux2014Package}/lib:$LD_LIBRARY_PATH";
+            test -d .nix-venv || ${pythonPkg.interpreter} -m venv .nix-venv
+            source .nix-venv/bin/activate
+          '';
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,6 @@
         packages.default = let
           projectConfig = pyproject.renderers.buildPythonPackage {
             inherit python;
-            project = pyproject;
           };
         in
           python.pkgs.buildPythonApplication (projectConfig

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,6 @@
 
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
-
-    pyproject-nix.url = "github:pyproject-nix/pyproject.nix";
-    pyproject-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = {
@@ -15,7 +12,6 @@
     nixpkgs,
     flake-utils,
     rust-overlay,
-    pyproject-nix,
   } @ inputs:
     flake-utils.lib.eachDefaultSystem
     (
@@ -23,45 +19,41 @@
         overlays = [(import rust-overlay)];
         pkgs = import nixpkgs {inherit system overlays;};
 
-        project = pyproject-nix.lib.project.loadPyproject {
-          projectRoot = ./.;
-        };
-
+        python = pkgs.python3;
         rust = pkgs.rust-bin.stable.latest.default;
-        python = pkgs.python3.override {
-          self = python;
-          packageOverrides = pyfinal: pyprev: {
-            inherit (pkgs) maturin;
-            typer-slim = pyfinal.typer;
-          };
+        rustPlatform = pkgs.makeRustPlatform {
+          rustc = rust;
+          cargo = rust;
         };
       in {
-        devShells.default = let
-          pythonEnv = python;
-          /*
-                              assert project.validators.validateVersionConstraints {inherit python;} == {};
-          python.withPackages (project.renderers.withPackages {inherit python;});
-          */
-        in
-          pkgs.mkShell {
-            buildInputs = with pkgs; [alejandra maturin rust pythonEnv];
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [alejandra maturin rust python];
 
-            shellHook = ''
-              export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib.outPath}/lib:${pkgs.pythonManylinuxPackages.manylinux2014Package}/lib:$LD_LIBRARY_PATH";
-              test -d .nix-venv || ${python.interpreter} -m venv .nix-venv
-              source .nix-venv/bin/activate
-            '';
+          shellHook = ''
+            export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib.outPath}/lib:${pkgs.pythonManylinuxPackages.manylinux2014Package}/lib:$LD_LIBRARY_PATH";
+            test -d .nix-venv || ${python.interpreter} -m venv .nix-venv
+            source .nix-venv/bin/activate
+          '';
+        };
+
+        packages.default = python.pkgs.buildPythonApplication rec {
+          name = "wakapi-anyide-${version}";
+          version = "0.6.8";
+          pyproject = true;
+
+          cargoDeps = rustPlatform.fetchCargoTarball {
+            inherit src;
+            hash = "sha256-qSU1QkYeGrVqWo+H+nB0DziJTjagaPczQhONV6ZFX14=";
           };
 
-        packages.default = let
-          # Returns an attribute set that can be passed to `buildPythonPackage`.
-          attrs = project.renderers.buildPythonPackage {
-            inherit python;
-          };
-        in
-          # Pass attributes to buildPythonPackage.
-          # Here is a good spot to add on any missing or custom attributes.
-          python.pkgs.buildPythonPackage attrs;
+          nativeBuildInputs = with pkgs; [
+            maturin
+            rustPlatform.cargoSetupHook
+            rustPlatform.maturinBuildHook
+          ];
+
+          src = ./.;
+        };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+  } @ inputs:
+    flake-utils.lib.eachDefaultSystem
+    (
+      system: let
+        overlays = [(import rust-overlay)];
+        pkgs = import nixpkgs {inherit system overlays;};
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [alejandra python313 rust-bin.stable.latest.default];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,12 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+
+    pyproject-nix.url = "github:pyproject-nix/pyproject.nix";
+    pyproject-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = {
@@ -11,6 +15,7 @@
     nixpkgs,
     flake-utils,
     rust-overlay,
+    pyproject-nix,
   } @ inputs:
     flake-utils.lib.eachDefaultSystem
     (
@@ -18,18 +23,45 @@
         overlays = [(import rust-overlay)];
         pkgs = import nixpkgs {inherit system overlays;};
 
-        rustPkg = pkgs.rust-bin.stable.latest.default;
-        pythonPkg = pkgs.python3;
-      in {
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [alejandra maturin pythonPkg rustPkg];
-
-          shellHook = ''
-            export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib.outPath}/lib:${pkgs.pythonManylinuxPackages.manylinux2014Package}/lib:$LD_LIBRARY_PATH";
-            test -d .nix-venv || ${pythonPkg.interpreter} -m venv .nix-venv
-            source .nix-venv/bin/activate
-          '';
+        project = pyproject-nix.lib.project.loadPyproject {
+          projectRoot = ./.;
         };
+
+        rust = pkgs.rust-bin.stable.latest.default;
+        python = pkgs.python3.override {
+          self = python;
+          packageOverrides = pyfinal: pyprev: {
+            inherit (pkgs) maturin;
+            typer-slim = pyfinal.typer;
+          };
+        };
+      in {
+        devShells.default = let
+          pythonEnv = python;
+          /*
+                              assert project.validators.validateVersionConstraints {inherit python;} == {};
+          python.withPackages (project.renderers.withPackages {inherit python;});
+          */
+        in
+          pkgs.mkShell {
+            buildInputs = with pkgs; [alejandra maturin rust pythonEnv];
+
+            shellHook = ''
+              export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib.outPath}/lib:${pkgs.pythonManylinuxPackages.manylinux2014Package}/lib:$LD_LIBRARY_PATH";
+              test -d .nix-venv || ${python.interpreter} -m venv .nix-venv
+              source .nix-venv/bin/activate
+            '';
+          };
+
+        packages.default = let
+          # Returns an attribute set that can be passed to `buildPythonPackage`.
+          attrs = project.renderers.buildPythonPackage {
+            inherit python;
+          };
+        in
+          # Pass attributes to buildPythonPackage.
+          # Here is a good spot to add on any missing or custom attributes.
+          python.pkgs.buildPythonPackage attrs;
       }
     );
 }


### PR DESCRIPTION
Adds a flake.nix with code to build and compile for the nix package manager.
can be used via `nix run` or `nix profile` to install permanently

Also contains a shell to setup a virtualenv and python for development using `nix shell` or direnv

I don't know if you want this in the main repo or if you would rather I keep it as a separate flake, but either is fine with me.